### PR TITLE
Make it compatible with clang in OSX

### DIFF
--- a/src/Disassembler.cpp
+++ b/src/Disassembler.cpp
@@ -8,6 +8,7 @@
 #include "Disassembler.h"
 #include "utils.h"
 
+#include <cstdlib>
 #include <cstdarg>
 #include <cstring>
 
@@ -15,7 +16,7 @@
 
 
 void Disassembler::append(const char* str)
-{	int len = strlen(str);
+{	long len = strlen(str);
 	memcpy(CodeAt, str, min(Code + sizeof Code - CodeAt, len));
 	CodeAt += len;
 }


### PR DESCRIPTION
```
Disassembler.cpp:19:22: error: no matching function for call to 'min'
        memcpy(CodeAt, str, min(Code + sizeof Code - CodeAt, len));
                            ^~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2544:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'int')
min(const _Tp& __a, const _Tp& __b)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2554:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'long'
min(initializer_list<_Tp> __t, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2536:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
min(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2562:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
min(initializer_list<_Tp> __t)
^
Disassembler.cpp:32:19: error: use of undeclared identifier 'abs'
        if ( UseFloat && abs(((value.iValue >> 23) & 0xff) ^ 0x80) <= 10
                         ^
Disassembler.cpp:35:11: error: use of undeclared identifier 'abs'
        else if (abs(value.iValue) <= 256)
                 ^
Disassembler.cpp:311:95: warning: format specifies type 'unsigned int' but the argument has type 'unsigned long' [-Wformat]
                        Labels.emplace(Addr + Instruct.Immd.iValue, stringf("L%x_%x", Addr + Instruct.Immd.iValue, Addr - 4*sizeof(uint64_t)));
                                                                                 ~~                                ^~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                 %lx
Disassembler.cpp:313:81: warning: format specifies type 'unsigned int' but the argument has type 'unsigned long' [-Wformat]
                        Labels.emplace(Instruct.Immd.uValue, stringf("L%x_%x", Instruct.Immd.uValue, Addr - 4*sizeof(uint64_t)));
                                                                          ~~                         ^~~~~~~~~~~~~~~~~~~~~~~~~
                                                                          %lx
Disassembler.cpp:330:56: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'uint32_t' (aka 'unsigned int') [-Wformat]
                        fprintf(Out, "\t%-48s # %04zx: %016llx %s\n", Code, Addr, i, Comment);
                                                ~~~~~                       ^~~~
                                                %04x
```
